### PR TITLE
Fix how the utility taxonomy is linked to supported post types

### DIFF
--- a/includes/class-wp-main-category-setup.php
+++ b/includes/class-wp-main-category-setup.php
@@ -30,11 +30,8 @@ class WP_Main_Category_Setup {
 
 		// Gather all the post types that use the category taxonomy.
 		foreach ( $post_types as $post_type ) {
-			if ( ! isset( $post_type->name ) ) {
-				continue;
-			}
-			if ( is_object_in_taxonomy( $post_type->name, 'category' ) ) {
-				$target_post_types[] = $post_type->name;
+			if ( is_object_in_taxonomy( $post_type, 'category' ) ) {
+				$target_post_types[] = $post_type;
 			}
 		}
 


### PR DESCRIPTION
`get_post_types()` returns post-type names by default, rather than objects,
which is fine because the names are all that are used anyway.